### PR TITLE
Fix: Windows compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@ function lighthouseCmd(options) {
       process.exit(1)
     }
   }
-  return `${cliPath} --chrome-flags="--no-sandbox --headless --disable-gpu"`
+  return `node ${cliPath} --chrome-flags="--no-sandbox --headless --disable-gpu"`
 }
 
 function siteName(site) {


### PR DESCRIPTION
Refer explicitly to `node` to run `lighthouse-cli.js` - tested using a Windows 10 machine.

Fixes #15 