### PR TITLE
Feature: Add support for reading site urls from a local text file

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,20 +63,32 @@ If you also want html reports include the `--html` option.
     housing_com.report.html   // Full html results for housing.com
     www_bbc_com.report.html   // Full html results for bbc.com
 
+There's also the option to read site urls from a text file, one per line.
+
+    lighthouse-batch -f sites.txt
+
+sites.txt
+
+```text
+https://www.bbc.com
+https://housing.com
+```
+
 All options
 
     lighthouse-batch [options]
 
     Options:
 
-      -h, --help             output usage information
-      -V, --version          output the version number
-      -s, --sites <sites>    a comma delimited list of site urls to analyze with Lighthouse
-      -p, --params <params>  extra parameters to pass to lighthouse cli for each execution e.g. -p "--perf --quiet"
-      -h, --html             generate an html report alongside the json report
-      -o, --out [out]        the output folder to place reports, defaults to './report/lighthouse'
-      -g, --use-global       use a global lighthouse install instead of the dependency version
-      -v, --verbose          enable verbose logging
+        -V, --version          output the version number
+        -s, --sites [sites]    a comma delimited list of site urls to analyze with Lighthouse (default: )
+        -f, --file [path]      an input file with a site url per-line to analyze with Lighthouse (default: null)
+        -p, --params <params>  extra parameters to pass to lighthouse cli for each execution e.g. -p "--perf --quiet" (default: null)
+        -h, --html             generate an html report alongside the json report
+        -o, --out [out]        the output folder to place reports, defaults to './report/lighthouse'
+        -g, --use-global       use a global lighthouse install instead of the dependency version
+        -v, --verbose          enable verbose logging
+        -h, --help             output usage information
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,6 @@ All options
 
     Options:
 
-        -V, --version          output the version number
         -s, --sites [sites]    a comma delimited list of site urls to analyze with Lighthouse (default: )
         -f, --file [path]      an input file with a site url per-line to analyze with Lighthouse (default: null)
         -p, --params <params>  extra parameters to pass to lighthouse cli for each execution e.g. -p "--perf --quiet" (default: null)
@@ -88,7 +87,7 @@ All options
         -o, --out [out]        the output folder to place reports, defaults to './report/lighthouse'
         -g, --use-global       use a global lighthouse install instead of the dependency version
         -v, --verbose          enable verbose logging
-        -h, --help             output usage information
+        --help                 output usage information
 
 ## Notes
 

--- a/index.js
+++ b/index.js
@@ -52,7 +52,20 @@ function execute(options) {
 }
 
 function sitesInfo(options) {
-  return options.sites.map(url => {
+  let sites = []
+  if (options.file) {
+    try {
+      const contents = fs.readFileSync(options.file, 'utf8')
+      sites = contents.trim().split('\n')
+    } catch (e) {
+      console.error(`Failed to read file ${options.file}, aborting.\n`, e)
+      process.exit(1)
+    }
+  }
+  if (options.sites) {
+    sites = sites.concat(options.sites)
+  }
+  return sites.map(url => {
     url = url.trim()
     if (!url.match(/^https?:/)) {
       if (!url.startsWith('//')) url = `//${url}`

--- a/run.js
+++ b/run.js
@@ -6,7 +6,8 @@ const execute = require('./index')
 
 program
   .version(require('./package.json').version)
-  .option('-s, --sites <sites>', 'a comma delimited list of site urls to analyze with Lighthouse', (str) => str.split(','), [])
+  .option('-s, --sites [sites]', 'a comma delimited list of site urls to analyze with Lighthouse', (str) => str.split(','), [])
+  .option('-f, --file [path]', 'an input file with a site url per-line to analyze with Lighthouse', null, '')
   .option('-p, --params <params>', 'extra parameters to pass to lighthouse cli for each execution e.g. -p "--perf --quiet"', null, '')
   .option('-h, --html', 'generate an html report alongside the json report')
   .option('-o, --out [out]', `the output folder to place reports, defaults to '${execute.OUT}'`)


### PR DESCRIPTION
Fix #7 with option to read list of site URLs, one per line, from text file.

e.g.  `lighthouse-batch -f sites.txt`

sites.txt
```
https://www.bbc.com
https://housing.com
```