### PR TITLE
Bump shelljs version

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,6 @@
   "dependencies": {
     "commander": "^2.9.0",
     "lighthouse": "^5.1.0",
-    "shelljs": "^0.7.6"
+    "shelljs": "^0.8.4"
   }
 }


### PR DESCRIPTION
Hi Mike,

Thanks for creating this awesome package – it works really well!

This PR fixes Node.js 14 warnings caused by an older version of `shelljs`.  For context: https://github.com/shelljs/shelljs/issues/991