### PR TITLE
Add option to retain testing URL's directory structure

### DIFF
--- a/run.js
+++ b/run.js
@@ -27,6 +27,10 @@ program
     `the output folder to place reports, defaults to '${execute.OUT}'`
   )
   .option(
+    "--retain-url-directory",
+    "retain the path of url as sub-directories, instead of replace slash with underscore"
+  )
+  .option(
     "--score <threshold>",
     `average score for each site to meet (1-100)`,
     Number


### PR DESCRIPTION
Some may prefer to put reports into URL's original directory structure

New behavior

```
http://example.com => $OUT/example_com.report.json
http://example.com/ => $OUT/example_com.report.json
http://example.com/?a=b => $OUT/example_com/_a=b.report.json
http://example.com/a/b/c => $OUT/example_com/a/b/c.report.json
```

This can be enabled with `--retain-url-directory`