### PR TITLE
Fixes cannot find module

### DIFF
--- a/index.js
+++ b/index.js
@@ -186,7 +186,7 @@ function lighthouseScript(options, log) {
     }
   }
   log(`Targeting local Lighthouse cli at '${cliPath}'`);
-  return `node ${cliPath}`;
+  return `node "${cliPath}"`;
 }
 
 function siteName(site) {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "commander": "^2.9.0",
-    "lighthouse": "^8.3.0",
+    "lighthouse": "^8.6.0",
     "shelljs": "^0.8.4"
   }
 }


### PR DESCRIPTION
Fixes issue where module cannot be found if there is a space in the path to lighthouse-cli. 

Fixes #61 