### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "commander": "^2.9.0",
-    "lighthouse": "^8.3.0",
+    "lighthouse": "^10.1.0",
     "shelljs": "^0.8.4"
   }
 }


### PR DESCRIPTION
Bump lighthouse dependency.
Fixes the "Unable to connect to Chrome" error seen below:

>>>>>>
Thu, 20 Apr 2023 18:43:03 GMT LH:ChromeLauncher Waiting for browser.....√ 
Thu, 20 Apr 2023 18:43:04 GMT LH:status Connecting to browser 
Thu, 20 Apr 2023 18:43:04 GMT LH:CriConnection:warn Cannot create new tab; reusing open tab. 
Thu, 20 Apr 2023 18:43:04 GMT LH:status Disconnecting from browser... 
Thu, 20 Apr 2023 18:43:04 GMT LH:status Cleaning origin data 
Thu, 20 Apr 2023 18:43:04 GMT LH:CriConnection:error sendRawMessage() was called without an established connection. 
Thu, 20 Apr 2023 18:43:04 GMT LH:GatherRunner disconnect:error sendRawMessage() was called without an established connection. 
Thu, 20 Apr 2023 18:43:04 GMT LH:ChromeLauncher Killing Chrome instance 2464 Unable to connect to Chrome
15/15: Lighthouse analysis FAILED for <url removed>